### PR TITLE
Fixed Exception in loading SDK on Windows. (issue #13)

### DIFF
--- a/crypto/src/main/java/com/virgilsecurity/crypto/virgil_crypto_javaJNI.java
+++ b/crypto/src/main/java/com/virgilsecurity/crypto/virgil_crypto_javaJNI.java
@@ -500,20 +500,21 @@ public class virgil_crypto_javaJNI {
 		// Build native library name according to current system
 		String osName = System.getProperty("os.name").toLowerCase();
 		String osArch = System.getProperty("os.arch").toLowerCase();
-
+		String suffix = "";
 		StringBuilder resourceName = new StringBuilder();
 		for (String os : new String[] { "linux", "windows", "mac os" }) {
 			if (osName.startsWith(os)) {
 				resourceName.append(os);
 
 				if ("windows".equals(os)) {
-					resourceName.append(File.separator).append(osArch);
+					resourceName.append("/").append(osArch);
+					suffix = ".dll";
 				}
 
 				break;
 			}
 		}
-		resourceName.append(File.separator).append(libraryName);
+		resourceName.append("/").append(libraryName);
 
 		InputStream in = virgil_crypto_javaJNI.class.getClassLoader().getResourceAsStream(resourceName.toString());
 		if (in == null) {
@@ -522,7 +523,7 @@ public class virgil_crypto_javaJNI {
 
 		byte[] buffer = new byte[1024];
 		int read = -1;
-		File temp = File.createTempFile(libraryName, "");
+		File temp = File.createTempFile(libraryName, suffix);
 		FileOutputStream fos = new FileOutputStream(temp);
 
 		while ((read = in.read(buffer)) != -1) {


### PR DESCRIPTION
Fixed issue with windows

Cannot load resource, because ClassLoader.getResourceAsSteram is not expecting backslashes in path to resource, thus cannot find resource
See ```virgil_crypto_javaJNI::loadNativeLibrary


    java.io.FileNotFoundException: Resource 'windows\amd64\virgil_crypto_java' not found
    Exception in thread "main" java.lang.UnsatisfiedLinkError:     com.virgilsecurity.crypto.virgil_crypto_javaJNI.swig_module_init()V
	at com.virgilsecurity.crypto.virgil_crypto_javaJNI.swig_module_init(Native Method)
	at com.virgilsecurity.crypto.virgil_crypto_javaJNI.<clinit>(virgil_crypto_javaJNI.java:487)
	at com.virgilsecurity.crypto.VirgilBase64.decode(VirgilBase64.java:76)
	at com.virgilsecurity.sdk.client.utils.ConvertionUtils.base64ToString(ConvertionUtils.java:131)
	at com.virgilsecurity.sdk.client.VirgilClient.responseToCard(VirgilClient.java:313)
	at com.virgilsecurity.sdk.client.VirgilClient.getCard(VirgilClient.java:222)

